### PR TITLE
Aye Chat v0.21.3: Switching default model to Gemini Pro 2.5

### DIFF
--- a/src/aye/config.py
+++ b/src/aye/config.py
@@ -24,7 +24,7 @@ MODELS = [
 ]
 
 # Default model identifier – kept separate so the order of MODELS stays unchanged.
-DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4.5"
+DEFAULT_MODEL_ID = "google/gemini-2.5-pro"
 
 
 def load_config() -> None:


### PR DESCRIPTION
Aye Chat v0.21.3: Switching default model to Gemini Pro 2.5