### PR TITLE
Fix pylint issues in plugin_base.py

### DIFF
--- a/src/aye/plugins/plugin_base.py
+++ b/src/aye/plugins/plugin_base.py
@@ -1,9 +1,20 @@
-from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+"""Base plugin class for the aye plugin system.
+
+This module provides the abstract base class that all plugins must inherit from.
+"""
+
+from abc import ABC
+from typing import Any, Dict, Optional
 from rich import print as rprint
 from aye.model.auth import get_user_config
 
+
 class Plugin(ABC):
+    """Abstract base class for all plugins.
+
+    Plugins must inherit from this class and implement required methods.
+    """
+
     name: str
     version: str = "1.0.0"
     premium: str = "free"  # one of: free, pro, team, enterprise
@@ -15,6 +26,11 @@ class Plugin(ABC):
         return get_user_config("debug", "off").lower() == "on"
 
     def init(self, cfg: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration.
+
+        Args:
+            cfg: Configuration dictionary for the plugin.
+        """
         self.verbose = bool(cfg.get("verbose", False))
 
         if self.debug:
@@ -22,14 +38,16 @@ class Plugin(ABC):
             rprint(f"[bold yellow]Plugin premium tier: {self.premium}[/]")
             rprint(f"[bold yellow]Plugin verbose mode: {self.verbose}[/]")
 
-    def on_command(self, command_name: str, params: Dict[str, Any] = {}) -> Optional[Dict[str, Any]]:
+    def on_command(
+        self, _command_name: str, _params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Handle a command with generic parameters.
-        
+
         Args:
-            command_name: Name of the command being executed
-            params: Dictionary containing command-specific parameters
-            
+            _command_name: Name of the command being executed
+            _params: Dictionary containing command-specific parameters
+
         Returns:
             Dictionary with response data, or None if plugin doesn't handle this command
         """


### PR DESCRIPTION
- Add module and class docstrings
- Add docstring to init method
- Remove unused imports (abstractmethod, List)
- Fix dangerous default value {} by using None
- Mark intentionally unused parameters with underscore prefix